### PR TITLE
Changed interface to not raise again

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ assert isValidBranch(branchA, trie.getRootHash(), "key1", "value1") == true
 # wrong key, return zero bytes
 assert isValidBranch(branchA, trie.getRootHash(), "key5", "") == true
 
-assert isValidBranch(branchB, trie.getRootHash(), "key1", "value1") # Key Error
+assert isValidBranch(branchB, trie.getRootHash(), "key1", "value1") # InvalidNode
 
 var x = getBranch(db, trie.getRootHash(), "key")
 # ==> [A]

--- a/eth_trie/memdb.nim
+++ b/eth_trie/memdb.nim
@@ -32,7 +32,7 @@ proc `==` *[T](x, y: openarray[T]): bool =
 
 proc get*(db: MemDB, key: openarray[byte]): Bytes =
   # echo "DB GET ", key.toHex
-  db.tbl[@key].value
+  db.tbl.getOrDefault(@key).value
 
 proc del*(db: MemDB, key: openarray[byte]) =
   # The database should ensure that the empty key is always active:

--- a/eth_trie/types.nim
+++ b/eth_trie/types.nim
@@ -16,7 +16,7 @@ type
 
 type
   PutProc = proc (db: RootRef, key, val: openarray[byte])
-  GetProc = proc (db: RootRef, key: openarray[byte]): Bytes
+  GetProc = proc (db: RootRef, key: openarray[byte]): Bytes # Must return empty seq if not found
   DelProc = proc (db: RootRef, key: openarray[byte])
   ContainsProc = proc (db: RootRef, key: openarray[byte]): bool
 

--- a/tests/examples.nim
+++ b/tests/examples.nim
@@ -1,5 +1,5 @@
 import
-  eth_trie/[memdb, binary, utils, branches, constants, types],
+  eth_trie/[memdb, binary, binaries, utils, branches, constants, types],
   nimcrypto/[keccak, hash], unittest
 
 suite "examples":
@@ -32,23 +32,15 @@ suite "examples":
     check isValidBranch(branchA, trie.getRootHash(), "key1", "value1") == true
     check isValidBranch(branchA, trie.getRootHash(), "key5", "") == true
 
-    try:
-      check isValidBranch(branchB, trie.getRootHash(), "key1", "value1") # Key Error
-    except KeyError:
-      check(true)
-    except:
-      check(false)
+    expect InvalidNode:
+      check isValidBranch(branchB, trie.getRootHash(), "key1", "value1")
 
     var x = getBranch(db, trie.getRootHash(), "key")
     # ==> [A]
     check x.len == 1
 
-    try:
+    expect InvalidKeyError::
       x = getBranch(db, trie.getRootHash(), "key123") # InvalidKeyError
-    except InvalidKeyError:
-      check(true)
-    except:
-      check(false)
 
     x = getBranch(db, trie.getRootHash(), "key5") # there is still branch for non-exist key
     # ==> [A]


### PR DESCRIPTION
Sorry, but I figured it would be more consistent (and easier to use) to return empty seq if key not found, so i'm changing this back.