### PR TITLE
Remove the dependency on eth_common

### DIFF
--- a/eth_trie.nimble
+++ b/eth_trie.nimble
@@ -9,7 +9,6 @@ skipDirs      = @["tests"]
 
 requires "nim >= 0.18.1",
          "rlp",
-         "eth_common",
          "nimcrypto",
          "ranges"
 

--- a/eth_trie/binary.nim
+++ b/eth_trie/binary.nim
@@ -1,6 +1,6 @@
 import
   ranges/[ptr_arith, typedranges, bitranges], rlp/types,
-  db, constants, binaries, utils
+  defs, db, binaries, utils
 
 export
   types, utils

--- a/eth_trie/branches.nim
+++ b/eth_trie/branches.nim
@@ -1,6 +1,6 @@
 import
   rlp/types, ranges/bitranges,
-  binary, binaries, db, utils
+  defs, binary, binaries, db, utils
 
 type
   DB = TrieDatabaseRef

--- a/eth_trie/constants.nim
+++ b/eth_trie/constants.nim
@@ -1,9 +1,0 @@
-import
-  ranges/typedranges, utils
-
-const
-  zeroBytesRange* = ByteRange()
-  blankStringHash* = hashFromHex "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
-  emptyRlp* = @[128.byte]
-  emptyRlpHash* = hashFromHex "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
-

--- a/eth_trie/db.nim
+++ b/eth_trie/db.nim
@@ -1,13 +1,9 @@
 import
   tables, hashes, sets,
-  nimcrypto/[hash, keccak], rlp, eth_common/eth_types,
-  constants, db_tracing
-
-export KeccakHash
+  nimcrypto/[hash, keccak], rlp,
+  defs, db_tracing
 
 type
-  BytesContainer* = BytesRange | Bytes | string
-
   MemDBRec = object
     refCount: int
     value: Bytes

--- a/eth_trie/defs.nim
+++ b/eth_trie/defs.nim
@@ -1,0 +1,28 @@
+import
+  rlp, ranges/typedranges, nimcrypto/hash
+
+export
+  typedranges, Bytes
+
+type
+  KeccakHash* = MDigest[256]
+  BytesContainer* = ByteRange | Bytes | string
+
+const
+  zeroBytesRange* = ByteRange()
+  blankStringHash* = "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470".toDigest
+  emptyRlp* = @[128.byte]
+  emptyRlpHash* = "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421".toDigest
+
+proc read*(rlp: var Rlp, T: typedesc[MDigest]): T {.inline.} =
+  result.data = rlp.read(type(result.data))
+
+proc append*(rlpWriter: var RlpWriter, a: MDigest) {.inline.} =
+  rlpWriter.append(a.data)
+
+proc unnecessary_OpenArrayToRange*(key: openarray[byte]): ByteRange =
+  ## XXX: The name of this proc is intentionally long, because it
+  ## performs a memory allocation and data copying that may be eliminated
+  ## in the future. Avoid renaming it to something similar as `toRange`, so
+  ## it can remain searchable in the code.
+  toRange(@key)

--- a/eth_trie/hexary.nim
+++ b/eth_trie/hexary.nim
@@ -1,8 +1,7 @@
 import
   tables,
-  nimcrypto/[keccak, hash, utils], ranges/ptr_arith,
-  rlp, eth_common/eth_types,
-  nibbles, constants, utils as trieUtils, db
+  nimcrypto/[keccak, hash, utils], ranges/ptr_arith, rlp,
+  defs, nibbles, utils as trieUtils, db
 
 type
   TrieNodeKey = object

--- a/eth_trie/nibbles.nim
+++ b/eth_trie/nibbles.nim
@@ -1,12 +1,12 @@
 import
-  rlp/types, constants
+  defs
 
 type
   NibblesRange* = object
-    bytes: BytesRange
+    bytes: ByteRange
     ibegin, iend: int
 
-proc initNibbleRange*(bytes: BytesRange): NibblesRange =
+proc initNibbleRange*(bytes: ByteRange): NibblesRange =
   result.bytes = bytes
   result.ibegin = 0
   result.iend = bytes.len * 2
@@ -90,7 +90,7 @@ proc sharedPrefixLen*(lhs, rhs: NibblesRange): int =
 proc startsWith*(lhs, rhs: NibblesRange): bool =
   sharedPrefixLen(lhs, rhs) == rhs.len
 
-proc hexPrefixDecode*(r: BytesRange): tuple[isLeaf: bool, nibbles: NibblesRange] =
+proc hexPrefixDecode*(r: ByteRange): tuple[isLeaf: bool, nibbles: NibblesRange] =
   result.nibbles = initNibbleRange(r)
   if r.len > 0:
     result.isLeaf = (r[0] and 0x20) != 0
@@ -100,7 +100,7 @@ proc hexPrefixDecode*(r: BytesRange): tuple[isLeaf: bool, nibbles: NibblesRange]
     result.isLeaf = false
 
 when false:
-  proc keyOf(r: BytesRange): NibblesRange =
+  proc keyOf(r: ByteRange): NibblesRange =
     let firstIdx = if r.len == 0: 0
                    elif (r[0] and 0x10) != 0: 1
                    else: 2

--- a/eth_trie/utils.nim
+++ b/eth_trie/utils.nim
@@ -1,8 +1,7 @@
 import
   strutils, parseutils,
-  rlp/types as rlpTypes, ranges/ptr_arith,
-  eth_common/eth_types, nimcrypto/[hash, keccak],
-  binaries
+  ranges/[typedranges, ptr_arith], nimcrypto/[hash, keccak],
+  defs, binaries
 
 #proc baseAddr*(x: Bytes): ptr byte = x[0].unsafeAddr
 
@@ -14,13 +13,13 @@ template checkValidHashZ*(x: untyped) =
   when x.type isnot KeccakHash:
     assert(x.len == 32 or x.len == 0)
 
-template isZeroHash*(x: BytesRange): bool =
+template isZeroHash*(x: ByteRange): bool =
   x.len == 0
 
-template toRange*(hash: KeccakHash): BytesRange =
+template toRange*(hash: KeccakHash): ByteRange =
   toTrieNodeKey(hash)
 
-proc toRange*(str: string): BytesRange =
+proc toRange*(str: string): ByteRange =
   var s = newSeq[byte](str.len)
   if str.len > 0:
     copyMem(s[0].addr, str[0].unsafeAddr, str.len)
@@ -41,7 +40,7 @@ proc hashFromHex*(bits: static[int], input: string): MDigest[bits] =
 
 template hashFromHex*(s: static[string]): untyped = hashFromHex(s.len * 4, s)
 
-proc keccakHash*(input: openArray[byte]): BytesRange =
+proc keccakHash*(input: openArray[byte]): ByteRange =
   var s = newSeq[byte](32)
   var ctx: keccak256
   ctx.init()
@@ -61,16 +60,16 @@ proc keccakHash*(dest: var openArray[byte], a, b: openArray[byte]) =
   ctx.finish dest
   ctx.clear()
 
-proc keccakHash*(a, b: openArray[byte]): BytesRange =
+proc keccakHash*(a, b: openArray[byte]): ByteRange =
   var s = newSeq[byte](32)
   keccakHash(s, a, b)
   result = toRange(s)
 
-template keccakHash*(input: BytesRange): BytesRange =
+template keccakHash*(input: ByteRange): ByteRange =
   keccakHash(input.toOpenArray)
 
-template keccakHash*(a, b: BytesRange): BytesRange =
+template keccakHash*(a, b: ByteRange): ByteRange =
   keccakHash(a.toOpenArray, b.toOpenArray)
 
-template keccakHash*(dest: var BytesRange, a, b: BytesRange) =
+template keccakHash*(dest: var ByteRange, a, b: ByteRange) =
   keccakHash(dest.toOpenArray, a.toOpenArray, b.toOpenArray)

--- a/tests/examples.nim
+++ b/tests/examples.nim
@@ -1,7 +1,7 @@
 import
   unittest,
   nimcrypto/[keccak, hash],
-  eth_trie/[db, binary, binaries, utils, branches, constants]
+  eth_trie/[defs, db, binary, binaries, utils, branches]
 
 suite "examples":
 

--- a/tests/test_bin_trie.nim
+++ b/tests/test_bin_trie.nim
@@ -1,6 +1,6 @@
 import
   unittest, random,
-  eth_trie/[db, binary, constants],
+  eth_trie/[defs, db, binary],
   test_utils
 
 suite "binary trie":

--- a/tests/test_json_suite.nim
+++ b/tests/test_json_suite.nim
@@ -1,7 +1,7 @@
 import
   os, json, tables, sequtils, strutils, algorithm,
   rlp/types, nimcrypto/utils,
-  eth_trie/[hexary, constants, db],
+  eth_trie/[defs, db, hexary],
   test_utils
 
 proc `==`(lhs: JsonNode, rhs: string): bool =

--- a/tests/test_sparse_binary_trie.nim
+++ b/tests/test_sparse_binary_trie.nim
@@ -1,6 +1,6 @@
 import
   unittest, random,
-  eth_trie/[db, sparse_binary, constants, sparse_proofs],
+  eth_trie/[defs, db, sparse_binary, sparse_proofs],
   test_utils
 
 suite "sparse binary trie":


### PR DESCRIPTION
The goal here was to reverse the dependency and make eth_trie usable in eth_common.

This depends on the following PR in Nimcrypto:
https://github.com/cheatfate/nimcrypto/pull/13